### PR TITLE
Change to use CURLFile when tweet with media.

### DIFF
--- a/Tests/StatusesTest.php
+++ b/Tests/StatusesTest.php
@@ -894,7 +894,7 @@ class StatusesTest extends TwitterTestCase
 
 		// Set POST request parameters.
 		$data = array();
-		$data['media[]'] = "@{$media}";
+		$data['media[]'] = new CurlFile($media);
 		$data['status'] = utf8_encode($status);
 		$data['in_reply_to_status_id'] = $in_reply_to_status_id;
 		$data['lat'] = $lat;
@@ -941,7 +941,7 @@ class StatusesTest extends TwitterTestCase
 
 		// Set POST request parameters.
 		$data = array();
-		$data['media[]'] = "@{$media}";
+		$data['media[]'] = new CurlFile($media);
 		$data['status'] = utf8_encode($status);
 
 		$this->client->expects($this->once())

--- a/src/Statuses.php
+++ b/src/Statuses.php
@@ -512,7 +512,7 @@ class Statuses extends Object
 		// Set POST data.
 		$data = array(
 			'status' => utf8_encode($status),
-			'media[]' => "@{$media}"
+			'media[]' => new CurlFile($media)
 		);
 
 		$header = array('Content-Type' => 'multipart/form-data');


### PR DESCRIPTION
In Joomla CMS if we post a new tweet with media we receive error:

Deprecated: curl_setopt_array(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead in libraries/joomla/http/transport/curl.php on line 179

This commit simply changes the code to use CURLFile.